### PR TITLE
Optimizations + Bug Fixes

### DIFF
--- a/GameCube/include/rando/data.h
+++ b/GameCube/include/rando/data.h
@@ -185,8 +185,6 @@ namespace mod::rando
 
     struct CustomMessageHeaderInfo
     {
-        uint16_t minVersion;
-        uint16_t maxVersion;
         uint16_t headerSize;
         uint8_t totalLanguages;
         uint8_t padding[1];

--- a/GameCube/include/rando/seed.h
+++ b/GameCube/include/rando/seed.h
@@ -57,8 +57,8 @@ namespace mod::rando
         ObjectArchiveReplacement* m_ObjectArcReplacements = nullptr;
         uint32_t m_numLoadedObjectArcReplacements = 0;
 
-        uint32_t m_TotalMsgEntries = 0;
-        void* m_MsgTableInfo = nullptr;
+        uint8_t* m_MsgTableInfo = nullptr; // Custom message string data
+        uint32_t m_TotalMsgEntries = 0; // Number of currently loaded custom string
 
         // Member functions
        public:

--- a/GameCube/source/game_patch/05_itemMsgFunctions.cpp
+++ b/GameCube/source/game_patch/05_itemMsgFunctions.cpp
@@ -192,9 +192,9 @@ namespace mod::game_patch
         {
             if ( msgIds[i] == msgId )
             {
-                // mod::console << &seed->m_MsgTableInfo << "\n";
-                // mod::console << &messages << "\n";
-                // mod::console << &messages[msgOffsets[i]] << "\n";
+                mod::console << &seed->m_MsgTableInfo << "\n";
+                mod::console << &messages << "\n";
+                mod::console << &messages[msgOffsets[i]] << "\n";
                 return &messages[msgOffsets[i]];
             }
         }

--- a/GameCube/source/game_patch/05_itemMsgFunctions.cpp
+++ b/GameCube/source/game_patch/05_itemMsgFunctions.cpp
@@ -192,9 +192,9 @@ namespace mod::game_patch
         {
             if ( msgIds[i] == msgId )
             {
-                mod::console << &seed->m_MsgTableInfo << "\n";
-                mod::console << &messages << "\n";
-                mod::console << &messages[msgOffsets[i]] << "\n";
+                // mod::console << &seed->m_MsgTableInfo << "\n";
+                // mod::console << &messages << "\n";
+                // mod::console << &messages[msgOffsets[i]] << "\n";
                 return &messages[msgOffsets[i]];
             }
         }


### PR DESCRIPTION
Optimized some code for loading data from the seed GCI.

Upon changing seeds, m_TotalMsgEntries will be reset to 0, and m_MsgTableInfo will be cleared.

Upon changing seeds, all of the pointers with allocated memory will be set to nullptr after being cleared, as to prevent stale references from being used in other code.