### PR TITLE
Don't reload seed on file load if not changing seeds

### DIFF
--- a/GameCube/include/main.h
+++ b/GameCube/include/main.h
@@ -43,6 +43,17 @@ namespace mod
     uint32_t ulRand( uint32_t range );
 
     void handleInput( uint32_t inputs );
+    
+    // Inline randoIsEnabled, as it's short enough to use less memory when inlined
+    inline bool randoIsEnabled(rando::Randomizer* rando)
+    {
+        if (!rando)
+        {
+            return false;
+        }
+        
+        return rando->m_Enabled;
+    }
 
     // Function hook handlers & trampolines
     void handle_fapGm_Execute( void );

--- a/GameCube/include/rando/randomizer.h
+++ b/GameCube/include/rando/randomizer.h
@@ -21,9 +21,11 @@ namespace mod::rando
     class Randomizer
     {
        public:
-        Randomizer( SeedInfo* seedInfo );
+        Randomizer( SeedInfo* seedInfo, uint8_t selectedSeed );
         ~Randomizer();
 
+        void loadSeed( SeedInfo* seedInfo, uint8_t selectedSeed );
+        void changeSeed( SeedInfo* seedInfo, uint8_t newSeed );
         void initSave( void );
 
         void onStageLoad( void );
@@ -47,8 +49,10 @@ namespace mod::rando
 
        public:
         SeedInfo* m_SeedInfo = nullptr;     // SeedInfo associated with this randomizer instance
-        bool m_SeedInit = false;            // True if seed-specific patches, flags, etc. have been applied to the save-file
         Seed* m_Seed;
+        bool m_Enabled = true;              // True if the randomizer is currently enabled
+        bool m_SeedInit = false;            // True if seed-specific patches, flags, etc. have been applied to the save-file
+        uint8_t m_CurrentSeed = 0xFF;       // The seed that is currently loaded
     };
 }     // namespace mod::rando
 #endif

--- a/GameCube/source/events.cpp
+++ b/GameCube/source/events.cpp
@@ -30,7 +30,7 @@ namespace mod::events
 
     void onLoad( rando::Randomizer* randomizer )
     {
-        if ( randomizer )
+        if ( randoIsEnabled( randomizer ) )
         {
             randomizer->onStageLoad();
         }
@@ -38,7 +38,7 @@ namespace mod::events
 
     void offLoad( rando::Randomizer* randomizer )
     {
-        if ( randomizer )
+        if ( randoIsEnabled( randomizer ) )
         {
             // Check if the seed is already applied to the save-file (flags etc.)
             // Try to do it otherwise
@@ -58,7 +58,7 @@ namespace mod::events
 
     void onRELLink( rando::Randomizer* randomizer, libtp::tp::dynamic_link::DynamicModuleControl* dmc )
     {
-        if ( randomizer )
+        if ( randoIsEnabled( randomizer ) )
         {
             randomizer->overrideREL();
         }
@@ -307,7 +307,7 @@ namespace mod::events
 
     void onDZX( rando::Randomizer* randomizer, libtp::tp::dzx::ChunkTypeInfo* chunkTypeInfo )
     {
-        if ( randomizer )
+        if ( randoIsEnabled( randomizer ) )
         {
             randomizer->overrideDZX( chunkTypeInfo );
         }
@@ -316,7 +316,7 @@ namespace mod::events
 
     int32_t onPoe( rando::Randomizer* randomizer, uint8_t flag )
     {
-        if ( randomizer )
+        if ( randoIsEnabled( randomizer ) )
         {
             return randomizer->getPoeItem( flag );
         }
@@ -329,7 +329,7 @@ namespace mod::events
 
     uint8_t onSkyCharacter( rando::Randomizer* randomizer )
     {
-        if ( randomizer )
+        if ( randoIsEnabled( randomizer ) )
         {
             return randomizer->getSkyCharacter();
         }
@@ -342,7 +342,7 @@ namespace mod::events
 
     void onARC( rando::Randomizer* randomizer, void* data, int roomNo, rando::FileDirectory fileDirectory )
     {
-        if ( randomizer )
+        if ( randoIsEnabled( randomizer ) )
         {
             randomizer->overrideARC( reinterpret_cast<uint32_t>( data ), fileDirectory, roomNo );
         }
@@ -350,7 +350,7 @@ namespace mod::events
 
     void onBugReward( rando::Randomizer* randomizer, uint32_t msgEventAddress, uint8_t bugID )
     {
-        if ( randomizer )
+        if ( randoIsEnabled( randomizer ) )
         {
             uint8_t itemID = randomizer->overrideBugReward( bugID );
             *reinterpret_cast<uint16_t*>( ( *reinterpret_cast<uint32_t*>( msgEventAddress + 0xA04 ) + 0x3580 ) + 0x6 ) =
@@ -366,7 +366,7 @@ namespace mod::events
 
     void onHiddenSkill( rando::Randomizer* randomizer, uint16_t eventIndex )
     {
-        if ( randomizer )
+        if ( randoIsEnabled( randomizer ) )
         {
             libtp::tp::d_item::execItemGet( randomizer->getHiddenSkillItem( eventIndex ) );
         }
@@ -463,7 +463,7 @@ namespace mod::events
     bool proc_query042( void* unk1, void* unk2, int32_t unk3 )
     {
         // Check to see if currently in one of the Ordon interiors
-        if ( randomizer )
+        if ( randoIsEnabled( randomizer ) )
         {
             if ( randomizer->m_Seed->m_Header->transformAnywhere )
             {
@@ -637,7 +637,7 @@ namespace mod::events
             return;
         }
 
-        if ( randomizer )
+        if ( randoIsEnabled( randomizer ) )
         {
             if ( randomizer->m_Seed->m_Header->transformAnywhere )
             {

--- a/GameCube/source/game_patch/02_modifyItemData.cpp
+++ b/GameCube/source/game_patch/02_modifyItemData.cpp
@@ -865,7 +865,7 @@ namespace mod::game_patch
         d_item::ItemFunc onGetFusedShadow3 = []()
         {
             d_save::onCollectCrystal( &d_com_inf_game::dComIfG_gameInfo.save.save_file.player.player_collect, '\x02' );
-            if ( randomizer )
+            if ( randoIsEnabled( randomizer ) )
             {
                 // If the player has the castle requirement set to Fused Shadows.
                 if ( randomizer->m_Seed->m_Header->castleRequirements == 1 )
@@ -897,7 +897,7 @@ namespace mod::game_patch
         d_item::ItemFunc onGetMirrorShard4 = []()
         {
             d_save::onCollectMirror( &d_com_inf_game::dComIfG_gameInfo.save.save_file.player.player_collect, '\x03' );
-            if ( randomizer )
+            if ( randoIsEnabled( randomizer ) )
             {
                 // If the player has the castle requirement set to Mirror Shards.
                 if ( randomizer->m_Seed->m_Header->castleRequirements == 2 )

--- a/GameCube/source/game_patch/04_verifyItemFunctions.cpp
+++ b/GameCube/source/game_patch/04_verifyItemFunctions.cpp
@@ -1,6 +1,7 @@
 #include <cinttypes>
 #include <cstring>
 
+#include "main.h"
 #include "data/items.h"
 #include "events.h"
 #include "game_patch/game_patch.h"
@@ -170,7 +171,7 @@ namespace mod::game_patch
     uint32_t _04_verifyProgressiveItem( rando::Randomizer* randomizer, uint32_t itemID )
     {
         using namespace libtp::data::items;
-        if ( randomizer )
+        if ( randoIsEnabled( randomizer ) )
         {
             switch ( itemID )
             {

--- a/GameCube/source/game_patch/05_itemMsgFunctions.cpp
+++ b/GameCube/source/game_patch/05_itemMsgFunctions.cpp
@@ -148,8 +148,8 @@ namespace mod::game_patch
 
     const char* _05_getMsgById( rando::Randomizer* randomizer, uint32_t msgId )
     {
-        // Make sure the randomizer is loaded
-        if ( !randomizer )
+        // Make sure the randomizer is loaded/enabled
+        if ( !randoIsEnabled( randomizer ) )
         {
             return nullptr;
         }
@@ -192,9 +192,8 @@ namespace mod::game_patch
         {
             if ( msgIds[i] == msgId )
             {
-                mod::console << &seed->m_MsgTableInfo << "\n";
+                mod::console << reinterpret_cast<void*>(msgTableInfoRaw) << "\n";
                 mod::console << &messages << "\n";
-                mod::console << &messages[msgOffsets[i]] << "\n";
                 return &messages[msgOffsets[i]];
             }
         }

--- a/GameCube/source/rando/randomizer.cpp
+++ b/GameCube/source/rando/randomizer.cpp
@@ -31,10 +31,22 @@
 
 namespace mod::rando
 {
-    Randomizer::Randomizer( SeedInfo* seedInfo )
+    Randomizer::Randomizer( SeedInfo* seedInfo, uint8_t selectedSeed )
     {
         mod::console << "Rando loading...\n";
+        loadSeed( seedInfo, selectedSeed );
+    }
 
+    Randomizer::~Randomizer( void )
+    {
+        mod::console << "Rando unloading...\n";
+
+        // Clear Seed
+        delete m_Seed;
+    }
+
+    void Randomizer::loadSeed( SeedInfo* seedInfo, uint8_t selectedSeed )
+    {
         if ( seedInfo->fileIndex == 0xFF )
         {
             mod::console << "<Randomizer> Error: No such seed (0xFF)\n";
@@ -44,18 +56,24 @@ namespace mod::rando
             mod::console << "Seed: " << seedInfo->header.seed << "\n";
             // Load the seed
             m_SeedInfo = seedInfo;
+            m_CurrentSeed = selectedSeed;
             m_Seed = new Seed( CARD_SLOT_A, seedInfo );
             // Load checks for first load
             onStageLoad();
         }
     }
 
-    Randomizer::~Randomizer( void )
+    void Randomizer::changeSeed( SeedInfo* seedInfo, uint8_t newSeed )
     {
-        mod::console << "Rando unloading...\n";
-
-        // Clear Seed
+        mod::console << "Seed unloading...\n";
         delete m_Seed;
+        m_SeedInfo = nullptr;
+        m_Seed = nullptr;
+        m_SeedInit = false;
+        m_CurrentSeed = 0xFF;
+        
+        mod::console << "Seed Loading...\n";
+        loadSeed( seedInfo, newSeed );
     }
 
     void Randomizer::initSave( void )

--- a/GameCube/source/user_patch/05_newFileFunctions.cpp
+++ b/GameCube/source/user_patch/05_newFileFunctions.cpp
@@ -6,6 +6,7 @@
  */
 #include <cinttypes>
 
+#include "main.h"
 #include "events.h"
 #include "rando/data.h"
 #include "rando/randomizer.h"
@@ -55,7 +56,7 @@ namespace mod::user_patch
 
     void loadShopModels( rando::Randomizer* randomizer, bool set )
     {
-        if ( set && randomizer )
+        if ( set && randoIsEnabled( randomizer ) )
         {
             randomizer->m_Seed->loadShopModels();
         }


### PR DESCRIPTION
This change means that the randomizer itself is never cleared from memory, and thus any checks for this have been changed to use the new randoIsEnabled function.

Fixed a bug in loadCustomText that would cause an incorrect index to be used if some languages were excluded from the seed GCI.

Removed instances of setting cleared pointers to nullptr when unloaded a seed, as they don't actually get used once the seed is unloaded.