### PR TITLE
Add CT hint sign; fix Ordon sign issue

### DIFF
--- a/GameCube/source/events.cpp
+++ b/GameCube/source/events.cpp
@@ -1377,11 +1377,16 @@ namespace mod::events
 
             case StageIDs::Ordon_Village:
             {
-                localSignActor.pos.x = 687.89f;
-                localSignActor.pos.y = 800.f;
-                localSignActor.pos.z = -1424.16f;
-                localSignActor.rot[1] = static_cast<int16_t>(0xA019);
-                tools::spawnActor(1, localSignActor);
+                // Need to check for room 1 or we get a floating sign near the
+                // roof of Sera's Shop.
+                if (roomIDX == 1)
+                {
+                    localSignActor.pos.x = 687.89f;
+                    localSignActor.pos.y = 800.f;
+                    localSignActor.pos.z = -1424.16f;
+                    localSignActor.rot[1] = static_cast<int16_t>(0xA019);
+                    tools::spawnActor(1, localSignActor);
+                }
                 break;
             }
 
@@ -1448,6 +1453,16 @@ namespace mod::events
                     localSignActor.rot[1] = static_cast<int16_t>(0x0000);
                     tools::spawnActor(16, localSignActor);
                 }
+                break;
+            }
+
+            case StageIDs::Castle_Town:
+            {
+                localSignActor.pos.x = 0.f;
+                localSignActor.pos.y = -200.f;
+                localSignActor.pos.z = 835.f;
+                localSignActor.rot[1] = static_cast<int16_t>(0x0000);
+                tools::spawnActor(0, localSignActor);
                 break;
             }
 

--- a/GameCube/source/main.cpp
+++ b/GameCube/source/main.cpp
@@ -1438,6 +1438,12 @@ namespace mod
                     // native node (8)
                     msgFlow->field_0x10 = 0x8;
                 }
+                else if (libtp::tp::d_a_alink::checkStageName(allStages[StageIDs::Castle_Town]))
+                {
+                    // For Castle Town, both 1 and 2 seem to work at the very
+                    // least. If you use 4, you will also get shiny shoes.
+                    msgFlow->field_0x10 = 0x2;
+                }
                 else if (libtp::tp::d_a_alink::checkStageName(allStages[StageIDs::Death_Mountain]))
                 {
                     // Death Mountain does not have a valid flow node for node 0 so we want it to use its


### PR DESCRIPTION
- Add Castle Town sign below the central fountain. Originally was planning to use the Jovani sign for CT, but that works differently (only shows a single textbox and not an array). This new location should be really good for Entrance Rando though, and I think it is better for the Jovani sign to have a single job.
- Fix issue where a floating sign showed up near the roof of Sera's Shop for some reason.