### PR TITLE
Fix being able to lose Poe items

### DIFF
--- a/GameCube/include/asm.h
+++ b/GameCube/include/asm.h
@@ -19,14 +19,14 @@
 
 // Original: li 0xE0
 // Normally loads the poesoul item id into r4
-#define e_hp_ExecDead_liOffset 0x247C
+#define e_hp_ExecDead_beqOffset 0x2440
 #define e_po_ExecDead_liOffset 0x3C9C
 
 // Original:
-// stb r0, 0x10c( r4 ) = > numPoeSouls
-// Normally increments poe count
-#define e_hp_ExecDead_incOffset 0x2354
-#define e_po_ExecDead_incOffset 0x36A8
+// lis r3,dComIfG_gameInfo@h
+// Normally increments poe count if not at 255
+#define e_hp_ExecDead_incOffset 0x233C
+#define e_po_ExecDead_incOffset 0x3690
 
 // d_a_obj_Lv5Key__Wait_offset:
 // 0xBC is offset to the text section relative to the start of the decompressed
@@ -46,9 +46,8 @@ namespace mod::assembly
         void handleDoLinkHook(libtp::tp::dynamic_link::DynamicModuleControl* dmc);
 
         // d_e_hp.rel
-        void asmAdjustPoeItemStart(void);
-        void asmAdjustPoeItemEnd(void);
-        int32_t handleAdjustPoeItem(void*);
+        void asmAdjustPoeItem(void);
+        void handleAdjustPoeItem(void*);
 
         // d_e_po.rel
         void asmAdjustAGPoeItemStart(void);

--- a/GameCube/include/main.h
+++ b/GameCube/include/main.h
@@ -57,6 +57,9 @@
 #define SEED_ACTION_CHANGE_SEED 2
 #define SEED_ACTION_FATAL 255
 
+// Number of bytes reserved for giving items to the player at arbitrary times via initGiveItemToPlayer
+#define GIVE_PLAYER_ITEM_RESERVED_BYTES 8
+
 // Converting item ids to msg ids and vice versa
 #define ITEM_TO_ID(item) (item + 0x64)
 #define ID_TO_ITEM(msgId) (msgId - 0x64)
@@ -228,6 +231,14 @@ namespace mod
 
     // State functions
     extern int32_t (*return_getLayerNo_common_common)(const char* stageName, int32_t roomId, int32_t layerOverride);
+
+    int32_t procCoGetItemInitCreateItem(const float pos[3],
+                                        int32_t item,
+                                        uint8_t unk3,
+                                        int32_t unk4,
+                                        int32_t unk5,
+                                        const float rot[3],
+                                        const float scale[3]);
 
     // Item creation functions. These are ran when the game displays an item though various means.
     int32_t handle_createItemForBoss(const float pos[3],

--- a/GameCube/source/asm/adjustPoeItem.s
+++ b/GameCube/source/asm/adjustPoeItem.s
@@ -1,16 +1,7 @@
-.global asmAdjustPoeItemStart
-.global asmAdjustPoeItemEnd
+.global asmAdjustPoeItem
+.hidden asmAdjustPoeItem
 
-.hidden asmAdjustPoeItemStart
-.hidden asmAdjustPoeItemEnd
-
-asmAdjustPoeItemStart:
+asmAdjustPoeItem:
+# r4 normally would need to be backed up here, but a different patch is skipping the code that would use the value in r4, so we don't need to back it up
 mr %r3,%r31 # e_hp_class
-bl handleAdjustPoeItem
-mr %r4,%r3 #The item to give
-
-# Restore important register values
-addi %r3,%r31,0x4D0
-
-asmAdjustPoeItemEnd:
-b 0
+b handleAdjustPoeItem

--- a/GameCube/source/asm/handler.cpp
+++ b/GameCube/source/asm/handler.cpp
@@ -24,10 +24,11 @@ namespace mod::assembly
         }
     }
 
-    int32_t handleAdjustPoeItem(void* e_hp_class)
+    void handleAdjustPoeItem(void* e_hp_class)
     {
-        uint8_t flag = *reinterpret_cast<uint8_t*>(reinterpret_cast<uint32_t>(e_hp_class) + 0x77B);
-        return events::onPoe(randomizer, flag);
+        const uint8_t flag = *reinterpret_cast<uint8_t*>(reinterpret_cast<uint32_t>(e_hp_class) + 0x77B);
+        const int32_t item = events::onPoe(randomizer, flag);
+        randomizer->addItemToEventQueue(static_cast<uint32_t>(item));
     }
 
     int32_t handleAdjustAGPoeItem(void* e_po_class)

--- a/GameCube/source/events.cpp
+++ b/GameCube/source/events.cpp
@@ -221,12 +221,20 @@ namespace mod::events
             // Generic Poe
             case D_A_E_HP:
             {
-                libtp::patch::writeStandardBranches(relPtrRaw + e_hp_ExecDead_liOffset,
-                                                    assembly::asmAdjustPoeItemStart,
-                                                    assembly::asmAdjustPoeItemEnd);
+                // Force the poe to be despawned immediately without playing the get item animation
+                performStaticASMReplacement(relPtrRaw + e_hp_ExecDead_beqOffset, ASM_NOP);
+
+                // Initialize giving the proper item rather than the poe soul
+                libtp::patch::writeBranchBL(relPtrRaw + e_hp_ExecDead_incOffset, assembly::asmAdjustPoeItem);
 
                 // Disable Poe increment (handled through item_get_func; see game_patches)
-                performStaticASMReplacement(relPtrRaw + e_hp_ExecDead_incOffset, ASM_NOP);
+                performStaticASMReplacement(relPtrRaw + e_hp_ExecDead_incOffset + 0x4, ASM_BRANCH(0x18));
+
+                // Skip checking for setting the flag for having obtained 20 poe souls
+
+                // This cannot be combined with the previous branch due to a value being stored in a class in the middle of the
+                // branches
+                performStaticASMReplacement(relPtrRaw + e_hp_ExecDead_incOffset + 0x24, ASM_BRANCH(0x28));
 
                 break;
             }
@@ -238,8 +246,9 @@ namespace mod::events
                                                     assembly::asmAdjustAGPoeItemStart,
                                                     assembly::asmAdjustAGPoeItemEnd);
 
-                // Disable Poe increment (handled through item_get_func; see game_patches)
-                performStaticASMReplacement(relPtrRaw + e_po_ExecDead_incOffset, ASM_NOP);
+                // Disable Poe increment (handled through item_get_func; see game_patches) and skip checking for setting the
+                // flag for having obtained 20 poe souls
+                performStaticASMReplacement(relPtrRaw + e_po_ExecDead_incOffset, ASM_BRANCH(0x44));
                 break;
             }
 

--- a/GameCube/source/game_patch/00_poe.cpp
+++ b/GameCube/source/game_patch/00_poe.cpp
@@ -6,6 +6,16 @@ namespace mod::game_patch
 {
     KEEP_FUNC void _00_handle_poeItem()
     {
-        libtp::tp::d_com_inf_game::dComIfG_gameInfo.save.save_file.player.player_collect.poe_count++;
+        uint8_t* poeCountPtr = &libtp::tp::d_com_inf_game::dComIfG_gameInfo.save.save_file.player.player_collect.poe_count;
+
+        // Do not increment the poe count if it is already at 60
+        const uint32_t currentPoeCount = *poeCountPtr;
+        if (currentPoeCount >= 60)
+        {
+            return;
+        }
+
+        // Increment the poe count
+        *poeCountPtr = static_cast<uint8_t>(currentPoeCount + 1);
     }
 } // namespace mod::game_patch

--- a/GameCube/source/main.cpp
+++ b/GameCube/source/main.cpp
@@ -489,8 +489,7 @@ namespace mod
                 }
 
                 getConsole().setLine(CONSOLE_PROTECTED_LINES - 1);
-                getConsole() << "\r"
-                             << "Press X/Y to select a seed\n"
+                getConsole() << "\r" << "Press X/Y to select a seed\n"
                              << "Press R + Z to close the console\n"
                              << "[" << static_cast<int32_t>(selectedSeed) + 1 << "/" << static_cast<int32_t>(numSeeds)
                              << "] Seed: " << seedList->m_minSeedInfo[selectedSeed].fileName << "\n";
@@ -820,7 +819,7 @@ namespace mod
                 uint8_t* reserveBytesPtr = &gameInfo->save.save_file.reserve.unk[0];
                 uint32_t itemToGive = 0xFF;
 
-                for (uint32_t i = 0; i < 4; i++)
+                for (uint32_t i = 0; i < GIVE_PLAYER_ITEM_RESERVED_BYTES; i++)
                 {
                     const uint32_t storedItem = reserveBytesPtr[i];
 
@@ -1067,6 +1066,22 @@ namespace mod
             }
         }
         return return_dStage_playerInit(stageDt, i_data, num, raw_data);
+    }
+
+    KEEP_FUNC int32_t procCoGetItemInitCreateItem(const float pos[3],
+                                                  int32_t item,
+                                                  uint8_t unk3,
+                                                  int32_t unk4,
+                                                  int32_t unk5,
+                                                  const float rot[3],
+                                                  const float scale[3])
+    {
+        if (giveItemToPlayer == ITEM_IN_QUEUE)
+        {
+            giveItemToPlayer = CLEAR_QUEUE;
+        }
+
+        return libtp::tp::f_op_actor_mng::createItemForPresentDemo(pos, item, unk3, unk4, unk5, rot, scale);
     }
 
     KEEP_FUNC int32_t handle_createItemForBoss(const float pos[3],
@@ -2189,7 +2204,6 @@ namespace mod
         // that doesnt exist we want the game to create one using the item id in mGtItm.
         if (giveItemToPlayer == ITEM_IN_QUEUE)
         {
-            giveItemToPlayer = CLEAR_QUEUE;
             libtp::tp::d_com_inf_game::dComIfG_gameInfo.play.mPlayer->mDemo.mParam0 = 0x100;
         }
 

--- a/GameCube/source/rando/randomizer.cpp
+++ b/GameCube/source/rando/randomizer.cpp
@@ -702,7 +702,7 @@ namespace mod::rando
         using namespace libtp::tp;
 
         uint8_t* reserveBytesPtr = d_com_inf_game::dComIfG_gameInfo.save.save_file.reserve.unk;
-        for (uint32_t i = 0; i < 4; i++)
+        for (uint32_t i = 0; i < GIVE_PLAYER_ITEM_RESERVED_BYTES; i++)
         {
             if (reserveBytesPtr[i] == 0)
             {

--- a/GameCube/subrel/boot/source/game_patch/06_asmOverrides.cpp
+++ b/GameCube/subrel/boot/source/game_patch/06_asmOverrides.cpp
@@ -1,5 +1,6 @@
 #include <cstdint>
 
+#include "main.h"
 #include "game_patch/game_patch.h"
 #include "asm_templates.h"
 #include "tp/d_item.h"
@@ -96,6 +97,9 @@ namespace mod::game_patch
         // Modify drawKanteraScreen to change the lantern meter color to match lantern light color from seed.
         uint32_t drawKanteraAddress = reinterpret_cast<uint32_t>(libtp::tp::d_meter2_draw::drawKanteraScreen);
         libtp::patch::writeBranchBL(drawKanteraAddress + 0xE4, events::modifyLanternMeterColor);
+
+        uint32_t procCoGetItemInitAddress = reinterpret_cast<uint32_t>(libtp::tp::d_a_alink::procCoGetItemInit);
+        libtp::patch::writeBranchBL(procCoGetItemInitAddress + 0x17C, procCoGetItemInitCreateItem);
 #ifdef TP_JP
         uint32_t checkWarpStartAddress = reinterpret_cast<uint32_t>(libtp::tp::d_a_alink::checkWarpStart);
 


### PR DESCRIPTION
This causes defeated Poes (excluding Arbiter Poes) to immediately despawn, and the item they would give is added to the queue to give to the player when they are free.

Also adjusted _00_handle_poeItem to not increment the Poe count if it is already at 60 or greater.

Also increased the amount of bytes used for queued items to 8.