### PR TITLE
Clear reserved bytes upon reaching title screen

### DIFF
--- a/GameCube/assets/eu.lst
+++ b/GameCube/assets/eu.lst
@@ -475,3 +475,6 @@
 
 // d_gameover.o
 8019b664:dispWait_init
+
+// d_file_select.o
+801845d8:dFile_select_c___create

--- a/GameCube/assets/jp.lst
+++ b/GameCube/assets/jp.lst
@@ -470,3 +470,6 @@
 
 // d_gameover.o
 8019b3cc:dispWait_init
+
+// d_file_select.o
+80184418:dFile_select_c___create

--- a/GameCube/assets/us.lst
+++ b/GameCube/assets/us.lst
@@ -486,3 +486,6 @@
 
 // f_pc_executor.o
 8002139c:fpcEx_IsExist
+
+// d_file_select.o
+801843cc:dFile_select_c___create

--- a/GameCube/include/main.h
+++ b/GameCube/include/main.h
@@ -32,6 +32,7 @@
 #include "tp/d_shop_system.h"
 #include "tp/f_op_actor.h"
 #include "tp/d_msg_flow.h"
+#include "tp/d_file_select.h"
 
 #ifdef TP_EU
 #include "tp/d_s_logo.h"
@@ -522,5 +523,9 @@ namespace mod
     extern int32_t (*return_seq_decide_yes)(libtp::tp::d_shop_system::dShopSystem* shopPtr,
                                             libtp::tp::f_op_actor::fopAc_ac_c* actor,
                                             void* msgFlow);
+
+    // Title Screen functions
+    void resetQueueOnFileSelectScreen(libtp::tp::d_file_select::dFile_select_c* thisPtr);
+    extern void (*return_dFile_select_c___create)(libtp::tp::d_file_select::dFile_select_c* thisPtr);
 } // namespace mod
 #endif

--- a/GameCube/subrel/boot/source/main.cpp
+++ b/GameCube/subrel/boot/source/main.cpp
@@ -33,6 +33,7 @@
 #include "gc_wii/OSInterrupt.h"
 #include "gc_wii/vi.h"
 #include "asm.h"
+#include "tp/d_file_select.h"
 
 #include <cstdint>
 #include <cstring>
@@ -266,6 +267,10 @@ namespace mod
 
         // Shop Functions
         return_seq_decide_yes = patch::hookFunction(libtp::tp::d_shop_system::seq_decide_yes, mod::handle_seq_decide_yes);
+
+        // Title Screen functions
+        return_dFile_select_c___create =
+            patch::hookFunction(libtp::tp::d_file_select::dFile_select_c___create, mod::resetQueueOnFileSelectScreen);
     }
 
     void initRandState()


### PR DESCRIPTION
This is because the reserved bytes that the queue uses to store the items to give are not cleared upon starting a new file, which means that the player could soft reset during the process of being given item(s), and then start a new file to be given those items on that new file.

Also moved resetting `giveItemToPlayer` to `QUEUE_EMPTY` to `resetQueueOnFileSelectScreen` as well, since it makes more sense for it to be reset there alongside the reserved bytes being cleared.