### PR TITLE
Allow for remapped Ooccoo destinations with Dungeon ER

### DIFF
--- a/GameCube/source/main.cpp
+++ b/GameCube/source/main.cpp
@@ -683,15 +683,16 @@ namespace mod
                     // getConsole() << "Shuffling Entrance\n";
 
                     // Note: we use 0 for lastMode so warping out with Ooccoo
-                    // works correctly with ER. We can potentially add more
-                    // logic here once more entrance types are randomized
-                    // (especially as it relates to riding on Epona, etc.)
+                    // (normally 0xC) works correctly with ER. We can
+                    // potentially add more logic here once more entrance types
+                    // are randomized (especially as it relates to riding on
+                    // Epona, etc.)
                     return gReturn_dComIfGp_setNextStage(libtp::data::stage::allStages[currentEntrance->getNewStageIDX()],
                                                          currentEntrance->getNewSpawn(),
                                                          currentEntrance->getNewRoomIDX(),
                                                          currentEntrance->getNewState(),
                                                          lastSpeed,
-                                                         0,
+                                                         lastMode == 0xC ? 0 : lastMode,
                                                          setPoint,
                                                          wipe,
                                                          lastAngle,

--- a/GameCube/source/main.cpp
+++ b/GameCube/source/main.cpp
@@ -682,12 +682,16 @@ namespace mod
                 {
                     // getConsole() << "Shuffling Entrance\n";
 
+                    // Note: we use 0 for lastMode so warping out with Ooccoo
+                    // works correctly with ER. We can potentially add more
+                    // logic here once more entrance types are randomized
+                    // (especially as it relates to riding on Epona, etc.)
                     return gReturn_dComIfGp_setNextStage(libtp::data::stage::allStages[currentEntrance->getNewStageIDX()],
                                                          currentEntrance->getNewSpawn(),
                                                          currentEntrance->getNewRoomIDX(),
                                                          currentEntrance->getNewState(),
                                                          lastSpeed,
-                                                         lastMode,
+                                                         0,
                                                          setPoint,
                                                          wipe,
                                                          lastAngle,


### PR DESCRIPTION
- Change lastMode to 0 when warping out with Ooccoo and ER is on
- Updated libtp_rel to point to latest zsrtp/master commit