### PR TITLE
Various trade item updates

### DIFF
--- a/GameCube/assets/eu.lst
+++ b/GameCube/assets/eu.lst
@@ -72,6 +72,7 @@
 80033060:setItem
 80034410:onLightDropGetFlag
 80033894:checkEmptyBottle
+80033cd4:setWarashibeItem
 
 // d_event.o
 800428A8:defaultSkipStb

--- a/GameCube/assets/jp.lst
+++ b/GameCube/assets/jp.lst
@@ -72,6 +72,7 @@
 80034368:onLightDropGetFlag
 80032bec:isTransformLV
 800337ec:checkEmptyBottle
+80033c2c:setWarashibeItem
 
 // d_event.o
 80042778:defaultSkipStb

--- a/GameCube/assets/us.lst
+++ b/GameCube/assets/us.lst
@@ -72,6 +72,7 @@
 800332f8:setLineUpItem
 80034368:onLightDropGetFlag
 800337ec:checkEmptyBottle
+80033c2c:setWarashibeItem
 
 // d_event.o
 80042778:defaultSkipStb

--- a/GameCube/include/functionHooks.h
+++ b/GameCube/include/functionHooks.h
@@ -307,6 +307,9 @@ namespace mod
     bool handle_isDarkClearLV(void* playerStatusPtr, int32_t twilightNode);
     extern bool (*gReturn_isDarkClearLV)(void* playerStatusPtr, int32_t twilightNode);
 
+    void handle_setWarashibeItem(libtp::tp::d_save::dSv_player_item_c* playerItemPtr, uint8_t itemID);
+    extern void (*gReturn_setWarashibeItem)(libtp::tp::d_save::dSv_player_item_c* playerItemPtr, uint8_t itemID);
+
     // Pause menu functions
     void handle_collect_save_open_init(uint8_t param_1);
     extern void (*gReturn_collect_save_open_init)(uint8_t param_1);

--- a/GameCube/include/game_patch/game_patch.h
+++ b/GameCube/include/game_patch/game_patch.h
@@ -55,6 +55,7 @@ namespace mod::game_patch
     void _02_modifyFoolishShopModel(uint8_t* foolishModelIndexes, uint32_t loopCurrentCount, uint32_t shopID);
     void _02_modifyShopModelScale(uint32_t shopID, uint32_t itemID);
     void giveNodeDungeonItems(const libtp::data::stage::AreaNodesID nodeId, const libtp::data::items::NodeDungeonItemType type);
+    void handleTradeItemFunc();
 
     extern const char* _02_hiddenSkillArc;
     extern const char* _02_mirrorShardArc;
@@ -142,6 +143,11 @@ namespace mod::game_patch
     void _02_SacredGrovePortalItemFunc();
     void _02_EldinBridgePortalItemFunc();
     void _02_UpperZoraRiverPortalItemFunc();
+    void _02_renadosLetterItemFunc();
+    void _02_invoiceItemFunc();
+    void _02_woodenStatueItemFunc();
+    void _02_iliasCharmItemFunc();
+    void _02_horseCallItemFunc();
     int32_t _02_bigWalletItemGetCheck();
     int32_t _02_giantWalletItemGetCheck();
     int32_t _02_firstFusedShadowItemGetCheck();

--- a/GameCube/source/functionHooks.cpp
+++ b/GameCube/source/functionHooks.cpp
@@ -164,6 +164,7 @@ namespace mod
     KEEP_VAR void (*gReturn_onSwitch_dSv_memBit)(libtp::tp::d_save::dSv_memBit_c* memoryBit, int32_t flag) = nullptr;
     KEEP_VAR void (*gReturn_onSwitch_dSv_info)(libtp::tp::d_save::dSv_info_c* memoryBit, int32_t flag, int32_t room) = nullptr;
     KEEP_VAR bool (*gReturn_isDarkClearLV)(void* playerStatusPtr, int32_t twilightNode) = nullptr;
+    KEEP_VAR void (*gReturn_setWarashibeItem)(libtp::tp::d_save::dSv_player_item_c* playerItemPtr, uint8_t itemID) = nullptr;
 
     // Pause menu functions
     KEEP_VAR void (*gReturn_collect_save_open_init)(uint8_t param_1) = nullptr;

--- a/GameCube/source/game_patch/02_modifyItemData.cpp
+++ b/GameCube/source/game_patch/02_modifyItemData.cpp
@@ -77,6 +77,21 @@ namespace mod::game_patch
         }
     }
 
+    void handleTradeItemFunc(uint8_t itemId)
+    {
+        // If the trade item slot is currently set to HorseCall, skip
+        // automatically updating the slot contents when the player finds a
+        // trade item.
+        libtp::tp::d_save::dSv_player_c* playerPtr = &libtp::tp::d_com_inf_game::dComIfG_gameInfo.save.save_file.player;
+        const uint8_t currentItemInSlot = playerPtr->player_item.item[21];
+        if (currentItemInSlot != libtp::data::items::Horse_Call)
+        {
+            libtp::tp::d_save::setItem(&libtp::tp::d_com_inf_game::dComIfG_gameInfo.save.save_file.player.player_item,
+                                       21,
+                                       itemId);
+        }
+    }
+
     uint32_t getFoolishModelRandomIndex(rando::Randomizer* randomizer, uint8_t* foolishModelIndexes, uint32_t loopCurrentCount)
     {
         uint32_t* randStatePtr = randomizer->getRandStatePtr();
@@ -833,6 +848,43 @@ namespace mod::game_patch
         events::setSaveFileEventFlag(libtp::data::flags::DECLINED_TO_HELP_IZA);
         events::setSaveFileEventFlag(libtp::data::flags::TALKED_TO_IZA_BEFORE_UZR_PORTAL);
         events::setSaveFileEventFlag(libtp::data::flags::IZA_1_MINIGAME_UNLOCKED);
+    }
+
+    KEEP_FUNC void _02_renadosLetterItemFunc()
+    {
+        handleTradeItemFunc(libtp::data::items::Renardos_Letter);
+    }
+
+    KEEP_FUNC void _02_invoiceItemFunc()
+    {
+        handleTradeItemFunc(libtp::data::items::Invoice);
+    }
+
+    KEEP_FUNC void _02_woodenStatueItemFunc()
+    {
+        // Still set "get wood carving" event bit like the vanilla function does.
+        libtp::tp::d_save::dSv_info_c* savePtr = &libtp::tp::d_com_inf_game::dComIfG_gameInfo.save;
+        libtp::tp::d_save::onEventBit(&savePtr->save_file.mEvent, 0x2204);
+
+        handleTradeItemFunc(libtp::data::items::Wooden_Statue);
+    }
+
+    KEEP_FUNC void _02_iliasCharmItemFunc()
+    {
+        handleTradeItemFunc(libtp::data::items::Ilias_Charm);
+    }
+
+    KEEP_FUNC void _02_horseCallItemFunc()
+    {
+        // Only automatically update trade item slot to HorseCall if it was empty.
+        libtp::tp::d_save::dSv_player_c* playerPtr = &libtp::tp::d_com_inf_game::dComIfG_gameInfo.save.save_file.player;
+        const uint8_t currentItemInSlot = playerPtr->player_item.item[21];
+        if (currentItemInSlot == libtp::data::items::NullItem)
+        {
+            libtp::tp::d_save::setItem(&libtp::tp::d_com_inf_game::dComIfG_gameInfo.save.save_file.player.player_item,
+                                       21,
+                                       libtp::data::items::Horse_Call);
+        }
     }
 
     KEEP_FUNC int32_t _02_bigWalletItemGetCheck()

--- a/GameCube/source/item_wheel_menu.cpp
+++ b/GameCube/source/item_wheel_menu.cpp
@@ -160,7 +160,10 @@ namespace mod::item_wheel_menu
                         j = (j + 1) % listLength; // Move to next index, wrapping around if needed.
                         if (events::haveItem(questItemsList[j]))
                         {
-                            playerPtr->player_item.item[21] = questItemsList[j];
+                            libtp::tp::d_save::setItem(
+                                &libtp::tp::d_com_inf_game::dComIfG_gameInfo.save.save_file.player.player_item,
+                                21,
+                                questItemsList[j]);
                             break;
                         }
                     } while (j != i);

--- a/GameCube/source/main.cpp
+++ b/GameCube/source/main.cpp
@@ -1750,6 +1750,19 @@ namespace mod
         return gReturn_isDarkClearLV(playerStatusPtr, twilightNode);
     }
 
+    KEEP_FUNC void handle_setWarashibeItem(libtp::tp::d_save::dSv_player_item_c* playerItemPtr, uint8_t itemID)
+    {
+        // If the trade item slot would be emptied (such as after showing the
+        // Invoice) and the player already has the HorseCall, update the trade
+        // item slot to be the HorseCall instead of removing the slot.
+        if (itemID == libtp::data::items::NullItem &&
+            libtp::tp::d_com_inf_game::dComIfGs_isItemFirstBit(libtp::data::items::Horse_Call))
+        {
+            itemID = libtp::data::items::Horse_Call;
+        }
+        gReturn_setWarashibeItem(playerItemPtr, itemID);
+    }
+
     KEEP_FUNC void handle_collect_save_open_init(uint8_t param_1)
     {
         game_patch::_07_checkPlayerStageReturn();

--- a/GameCube/subrel/boot/source/game_patch/02_modifyItemData.cpp
+++ b/GameCube/subrel/boot/source/game_patch/02_modifyItemData.cpp
@@ -522,6 +522,11 @@ namespace mod::game_patch
         itemFuncPtr[customItems::Sacred_Grove_Portal] = _02_SacredGrovePortalItemFunc;
         itemFuncPtr[customItems::Bridge_of_Eldin_Portal] = _02_EldinBridgePortalItemFunc;
         itemFuncPtr[customItems::Upper_Zoras_River_Portal] = _02_UpperZoraRiverPortalItemFunc;
+        itemFuncPtr[items::Renardos_Letter] = _02_renadosLetterItemFunc;
+        itemFuncPtr[items::Invoice] = _02_invoiceItemFunc;
+        itemFuncPtr[items::Wooden_Statue] = _02_woodenStatueItemFunc;
+        itemFuncPtr[items::Ilias_Charm] = _02_iliasCharmItemFunc;
+        itemFuncPtr[items::Horse_Call] = _02_horseCallItemFunc;
 
         // Some items need a valid getCheckFunc definition.
         itemGetCheckFuncPtr[items::Big_Wallet] = _02_bigWalletItemGetCheck;

--- a/GameCube/subrel/boot/source/main.cpp
+++ b/GameCube/subrel/boot/source/main.cpp
@@ -219,6 +219,7 @@ namespace mod
         gReturn_onSwitch_dSv_memBit = patch::hookFunction(libtp::tp::d_save::onSwitch_dSv_memBit, handle_onSwitch_dSv_memBit);
         gReturn_onSwitch_dSv_info = patch::hookFunction(libtp::tp::d_save::onSwitch_dSv_info, handle_onSwitch_dSv_info);
         gReturn_isDarkClearLV = patch::hookFunction(tp::d_save::isDarkClearLV, handle_isDarkClearLV);
+        gReturn_setWarashibeItem = patch::hookFunction(tp::d_save::setWarashibeItem, handle_setWarashibeItem);
 
         // Pause Menu Functions
         gReturn_collect_save_open_init =


### PR DESCRIPTION
- When finding a tradeItem, only automatically swaps the trade item slot if it was not currently on HorseCall.
- When finding the HorseCall, only automatically swaps the trade item slot if it was empty.
- When an NPC tries to set your trade item slot to empty, if you already have the HorseCall, change the slot to the HorseCall instead.
- Using the dPad to change the trade item slots contents now updates your equipped item image (if you had the trade item slot equipped).