### PR TITLE
Adjust Epona pos when loading next stage after opening cutscene

### DIFF
--- a/GameCube/assets/eu.lst
+++ b/GameCube/assets/eu.lst
@@ -48,6 +48,8 @@
 800250bc:dStage_playerInit
 80452d24:mStayNo
 80452d25:mOldStayNo
+80026de0:dStage_Create
+80408134:mDemoArcName
 
 // d_save.o
 80032B50:getRupeeMax

--- a/GameCube/assets/jp.lst
+++ b/GameCube/assets/jp.lst
@@ -48,6 +48,8 @@
 80025014:dStage_playerInit
 8044aea4:mStayNo
 8044aea5:mOldStayNo
+80026d38:dStage_Create
+804002d4:mDemoArcName
 
 // d_save.o
 80032AA8:getRupeeMax

--- a/GameCube/assets/us.lst
+++ b/GameCube/assets/us.lst
@@ -48,6 +48,8 @@
 80025014:dStage_playerInit
 80450D64:mStayNo
 80450D65:mOldStayNo
+80026D38:dStage_Create
+80406194:mDemoArcName
 
 // d_save.o
 80032AA8:getRupeeMax

--- a/GameCube/include/functionHooks.h
+++ b/GameCube/include/functionHooks.h
@@ -102,6 +102,9 @@ namespace mod
                                                 int32_t num,
                                                 void* raw_data);
 
+    void handle_dStage_Create();
+    extern void (*gReturn_dStage_Create)();
+
     // State functions
     extern int32_t (*gReturn_getLayerNo_common_common)(const char* stageName, int32_t roomId, int32_t layerOverride);
 

--- a/GameCube/source/events.cpp
+++ b/GameCube/source/events.cpp
@@ -145,12 +145,6 @@ namespace mod::events
                 savePtr->save_file.player.player_status_a.currentRupees =
                     mod::user_patch::walletValues[seedPtr->getHeaderPtr()->getWalletSize()][0];
             }
-
-            if (d_com_inf_game::dComIfGs_isEventBit(flags::ORDON_DAY_2_OVER))
-            {
-                // Place Epona out of bounds in Faron if Talo has been rescued since the game will spawn her in the air.
-                savePtr->save_file.player.horse_place.mPos.y = -1000.f;
-            }
         }
 
         // Check to see if currently in City and our last visited stage was not City.

--- a/GameCube/source/functionHooks.cpp
+++ b/GameCube/source/functionHooks.cpp
@@ -50,6 +50,8 @@ namespace mod
                                                   int32_t num,
                                                   void* raw_data) = nullptr;
 
+    KEEP_VAR void (*gReturn_dStage_Create)() = nullptr;
+
     KEEP_VAR void (*gReturn_dComIfGp_setNextStage)(const char* stage,
                                                    int16_t point,
                                                    int8_t roomNo,

--- a/GameCube/source/main.cpp
+++ b/GameCube/source/main.cpp
@@ -792,6 +792,82 @@ namespace mod
         return gReturn_dStage_playerInit(stageDt, i_data, num, raw_data);
     }
 
+    // Stage, room, point, layer
+    static const uint8_t openingCsEntrances[3][4] = {
+        {StageIDs::Faron_Woods, 1, 0x15, 0xD},
+        {StageIDs::Ordon_Spring, 1, 0x18, 0xD},
+        {StageIDs::Ordon_Village, 1, 0x1E, 0x9},
+    };
+
+    bool nextStageIsOpeningCutscene()
+    {
+        libtp::tp::d_stage::dStage_nextStage* nextStage = &libtp::tp::d_com_inf_game::dComIfG_gameInfo.play.mNextStage;
+        constexpr uint32_t totalOpeningCsEntrances = sizeof(openingCsEntrances) / sizeof(openingCsEntrances[0]);
+
+        for (uint32_t i = 0; i < totalOpeningCsEntrances; i++)
+        {
+            const uint8_t* entrance = openingCsEntrances[i];
+
+            if (!strcmp(nextStage->mStage, libtp::data::stage::allStages[entrance[0]]) && nextStage->mRoomNo == entrance[1] &&
+                nextStage->mPoint == entrance[2] && nextStage->mLayer == entrance[3])
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    KEEP_FUNC void handle_dStage_Create()
+    {
+        using namespace libtp::tp;
+
+        // When proceeding from the opening cutscene to the game, fix issue
+        // where Epona's position will remain wherever it was when the opening
+        // cutscene ended (either through skipping or ending naturally). We
+        // check against GAME_ACTIVE so we know we aren't returning to the title
+        // screen. Epona's stage is set to a fake value so that comparing the
+        // current stage against it never matches. This means Epona will not
+        // appear until the game specifically puts her somewhere (such as when
+        // you walk to Ordon Spring at the start of the prologue) or the player
+        // calls her, both of which overwrite the horse place to a normal value.
+        if (rando::gRandomizer->getGameState() == GameState::GAME_ACTIVE)
+        {
+            bool prevStageWasOpeningCutscene = false;
+
+            // Check string starts "Demo01_0". These comparisons are done over
+            // string compares since it uses fewer instruction bytes, executes
+            // fewer instructions, and does not require extra string data.
+            const uint32_t* demoNameAsWords = reinterpret_cast<const uint32_t*>(d_stage::mDemoArcName);
+            if (demoNameAsWords[0] == 0x44656D6F && demoNameAsWords[1] == 0x30315F30) // "Demo" and "01_0"
+            {
+                const uint8_t* demoNameAsBytes = reinterpret_cast<const uint8_t*>(d_stage::mDemoArcName);
+                if (demoNameAsBytes[9] == 0) // Check strLen is 9
+                {
+                    uint8_t lastCharByte = demoNameAsBytes[8];
+                    // Check final char in string is "1", "2", or "3", meaning
+                    // the string is "Demo01_01", "Demo01_02", or "Demo01_03".
+                    if (lastCharByte >= 0x31 && lastCharByte <= 0x33) // "1", "2", or "3"
+                    {
+                        prevStageWasOpeningCutscene = true;
+                    }
+                }
+            }
+
+            if (prevStageWasOpeningCutscene && !nextStageIsOpeningCutscene())
+            {
+                // Moving from the opening cutscene into the first stage outside
+                // of the opening cs, so hide Epona until the game manually
+                // places her or the player calls her.
+                strncpy(d_com_inf_game::dComIfG_gameInfo.save.save_file.player.horse_place.epona_current_stage,
+                        "FAKESTG",
+                        sizeof(d_com_inf_game::dComIfG_gameInfo.save.save_file.player.horse_place.epona_current_stage) - 1);
+            }
+        }
+
+        // Call the original function after our code
+        gReturn_dStage_Create();
+    }
+
     KEEP_FUNC int32_t procCoGetItemInitCreateItem(const float pos[3],
                                                   int32_t item,
                                                   uint8_t unk3,
@@ -832,8 +908,8 @@ namespace mod
             parameters = 0x9F;
         }
 
-        // If we are in hyrule field then the function is running to give us the Hot Springwater heart piece and we want it to
-        // spawn on the ground.
+        // If we are in hyrule field then the function is running to give us the Hot Springwater heart piece and we want it
+        // to spawn on the ground.
         if (libtp::tp::d_a_alink::checkStageName(libtp::data::stage::allStages[libtp::data::stage::StageIDs::Hyrule_Field]))
         {
             *const_cast<float*>(&pos[1]) = -190.f;
@@ -891,8 +967,8 @@ namespace mod
     {
         libtp::tp::d_a_itembase::ItemBase* item = static_cast<libtp::tp::d_a_itembase::ItemBase*>(actor);
 
-        // We determine whether to use the item_resource or the field_item_resource structs to spawn an item based on the item
-        // being created.
+        // We determine whether to use the item_resource or the field_item_resource structs to spawn an item based on the
+        // item being created.
         switch (item->m_itemNo)
         {
             case libtp::data::items::Empty_Bottle:
@@ -1152,8 +1228,8 @@ namespace mod
     {
         if (libtp::tp::d_a_alink::checkStageName(libtp::data::stage::allStages[libtp::data::stage::StageIDs::Cave_of_Ordeals]))
         {
-            // Return 1 to allow the player to collect the item from the floor 50 reward, as this will make the game think that
-            // the player has an empty bottle.
+            // Return 1 to allow the player to collect the item from the floor 50 reward, as this will make the game think
+            // that the player has an empty bottle.
             return 1;
         }
         return gReturn_checkEmptyBottle(playerItem);
@@ -1194,7 +1270,8 @@ namespace mod
     KEEP_FUNC int32_t handle_event000( void* messageFlow, void* nodeEvent, void* actrPtr )
     {
         // Prevent the hidden skill CS from setting the proper flags
-        if ( libtp::tp::d_a_alink::checkStageName( libtp::data::stage::allStages[libtp::data::stage::StageIDs::Hidden_Skill] ) )
+        if ( libtp::tp::d_a_alink::checkStageName( libtp::data::stage::allStages[libtp::data::stage::StageIDs::Hidden_Skill]
+    ) )
         {
             *reinterpret_cast<uint16_t*>( reinterpret_cast<uint32_t>( nodeEvent ) + 4 ) = 0x0000;
         }
@@ -1228,8 +1305,8 @@ namespace mod
                 // Clear the invalid msg value since it will be set by the game once our text is loaded.
                 msgFlow->mMsg = 0;
 
-                // When this byte is set, the current event is aborted. With unused nodes, it is set to 1 by default so we need
-                // to unset it.
+                // When this byte is set, the current event is aborted. With unused nodes, it is set to 1 by default so we
+                // need to unset it.
                 msgFlow->field_0x26 = 0;
 
                 if (libtp::tp::d_a_alink::checkStageName(allStages[StageIDs::Hyrule_Field]) ||
@@ -1520,9 +1597,9 @@ namespace mod
 
             switch (flag)
             {
-                // Case block for Wolf -> Human crash patches/bug fixes. Some cutscenes/events either crash or act weird if Link
-                // is Human but needs to be Wolf and the game no longer attempts to auto-transform Link once the Shadow Crystal
-                // has been obtained.
+                // Case block for Wolf -> Human crash patches/bug fixes. Some cutscenes/events either crash or act weird if
+                // Link is Human but needs to be Wolf and the game no longer attempts to auto-transform Link once the Shadow
+                // Crystal has been obtained.
                 case ENTERED_ORDON_SPRING_DAY_3:
                 {
                     if (libtp::tp::d_com_inf_game::dComIfGs_isEventBit(TRANSFORMING_UNLOCKED))
@@ -1533,9 +1610,9 @@ namespace mod
                     break;
                 }
 
-                // Case block for Human -> Wolf crash patches/bug fixes. Some cutscenes/events either crash or act weird if Link
-                // is Wolf but needs to be human and the game no longer attempts to auto-transform Link once the Shadow Crystal
-                // has been obtained.
+                // Case block for Human -> Wolf crash patches/bug fixes. Some cutscenes/events either crash or act weird if
+                // Link is Wolf but needs to be human and the game no longer attempts to auto-transform Link once the Shadow
+                // Crystal has been obtained.
                 case WATCHED_CUTSCENE_AFTER_BEING_CAPTURED_IN_FARON_TWILIGHT:
                 {
                     if (libtp::tp::d_com_inf_game::dComIfGs_isEventBit(TRANSFORMING_UNLOCKED))
@@ -1574,8 +1651,8 @@ namespace mod
                     {
                         if (darkClearLevelFlag == 0x7)
                         {
-                            playerStatusBPtr->transform_level_flag |= 0x8; // Set the flag for the last transformed twilight.
-                                                                           // Also puts Midna on the player's back
+                            playerStatusBPtr->transform_level_flag |= 0x8; // Set the flag for the last transformed
+                                                                           // twilight. Also puts Midna on the player's back
 
                             playerStatusBPtr->dark_clear_level_flag |= 0x8;
                         }
@@ -1590,8 +1667,8 @@ namespace mod
                     {
                         if (darkClearLevelFlag == 0x7) // All twilights completed
                         {
-                            playerStatusBPtr->transform_level_flag |= 0x8; // Set the flag for the last transformed twilight.
-                                                                           // Also puts Midna on the player's back
+                            playerStatusBPtr->transform_level_flag |= 0x8; // Set the flag for the last transformed
+                                                                           // twilight. Also puts Midna on the player's back
 
                             playerStatusBPtr->dark_clear_level_flag |= 0x8;
                         }
@@ -1865,8 +1942,8 @@ namespace mod
     {
         using namespace libtp::tp;
 
-        // If we are in Iza's hut and we have the bow, we want to update the save file bow item stored in g_meter2_info just in
-        // case the player started the minigame without it and somehow broke out of the minigame.
+        // If we are in Iza's hut and we have the bow, we want to update the save file bow item stored in g_meter2_info just
+        // in case the player started the minigame without it and somehow broke out of the minigame.
         if (d_a_alink::checkStageName(libtp::data::stage::allStages[libtp::data::stage::StageIDs::Zoras_River]))
         {
             if (events::haveItem(libtp::data::items::Heros_Bow))
@@ -2055,8 +2132,8 @@ namespace mod
 
     KEEP_FUNC int32_t handle_procCoGetItemInit(libtp::tp::d_a_alink::daAlink* linkActrPtr)
     {
-        // If we are giving a custom item, we want to set mParam0 to 0x100 so that instead of trying to search for an item actor
-        // that doesnt exist we want the game to create one using the item id in mGtItm.
+        // If we are giving a custom item, we want to set mParam0 to 0x100 so that instead of trying to search for an item
+        // actor that doesnt exist we want the game to create one using the item id in mGtItm.
         if (rando::gRandomizer->getGiveItemToPlayerStatus() == rando::EventItemStatus::ITEM_IN_QUEUE)
         {
             libtp::tp::d_com_inf_game::dComIfG_gameInfo.play.mPlayer->mDemo.mParam0 = 0x100;
@@ -2201,9 +2278,9 @@ namespace mod
     {
         libtp::tp::d_resource::dRes_info_c* resourcePtr = gReturn_getResInfo(arcName, objectInfo, size);
 
-        // Make sure the randomizer is enabled, as otherwise some arcs seem to get modifed that shouldn't. One example of this
-        // causing problems is when starting a file, and once you have control of Link, reset to go back to the title screen.
-        // Doing so will cause the game to crash if this code runs when the randomizer is disabled.
+        // Make sure the randomizer is enabled, as otherwise some arcs seem to get modifed that shouldn't. One example of
+        // this causing problems is when starting a file, and once you have control of Link, reset to go back to the title
+        // screen. Doing so will cause the game to crash if this code runs when the randomizer is disabled.
         rando::Randomizer* randoPtr = rando::gRandomizer;
         if (randoPtr->randomizerIsEnabled() && resourcePtr)
         {
@@ -2273,8 +2350,8 @@ namespace mod
         const int32_t roomID = libtp::tools::getCurrentRoomNo();
         libtp::tp::d_save::dSv_info_c* savePtr = &libtp::tp::d_com_inf_game::dComIfG_gameInfo.save;
 
-        // If we've already struck the pedestal in grove, we don't want to strike again since that would cause a softlock. We
-        // don't need to check the stage because the code that this handle is injected into only runs in Sacred Grove.
+        // If we've already struck the pedestal in grove, we don't want to strike again since that would cause a softlock.
+        // We don't need to check the stage because the code that this handle is injected into only runs in Sacred Grove.
         if ((roomID == 0x1) && d_save::isSwitch_dSv_memBit(&savePtr->memory.temp_flags, 0x63))
         {
             return false;
@@ -2342,11 +2419,11 @@ namespace mod
         }
     }
 
-    // This is called in the NON-MAIN thread which is loading the archive where `mountArchive->mIsDone = true;` would be called
-    // normally (this is the last thing that gets called before the archive is considered loaded). The archive is no longer
-    // automatically marked as loaded, so we need to do this ourselves when we are done. (This indicates that the archive is
-    // loaded, and whatever was waiting on it will see this byte change the next time it polls the completion status (polling
-    // happens once per frame?))
+    // This is called in the NON-MAIN thread which is loading the archive where `mountArchive->mIsDone = true;` would be
+    // called normally (this is the last thing that gets called before the archive is considered loaded). The archive is no
+    // longer automatically marked as loaded, so we need to do this ourselves when we are done. (This indicates that the
+    // archive is loaded, and whatever was waiting on it will see this byte change the next time it polls the completion
+    // status (polling happens once per frame?))
     KEEP_FUNC bool handle_mountArchive__execute(libtp::tp::m_Do_dvd_thread::mDoDvdThd_mountArchive_c* mountArchive)
     {
         const bool ret = gReturn_mountArchive__execute(mountArchive);

--- a/GameCube/source/main.cpp
+++ b/GameCube/source/main.cpp
@@ -792,51 +792,18 @@ namespace mod
         return gReturn_dStage_playerInit(stageDt, i_data, num, raw_data);
     }
 
-    // Stage, room, point, layer
-    static const uint8_t openingCsEntrances[3][4] = {
-        {StageIDs::Faron_Woods, 1, 0x15, 0xD},
-        {StageIDs::Ordon_Spring, 1, 0x18, 0xD},
-        {StageIDs::Ordon_Village, 1, 0x1E, 0x9},
-    };
-
-    bool nextStageIsOpeningCutscene()
-    {
-        libtp::tp::d_stage::dStage_nextStage* nextStage = &libtp::tp::d_com_inf_game::dComIfG_gameInfo.play.mNextStage;
-        constexpr uint32_t totalOpeningCsEntrances = sizeof(openingCsEntrances) / sizeof(openingCsEntrances[0]);
-
-        for (uint32_t i = 0; i < totalOpeningCsEntrances; i++)
-        {
-            const uint8_t* entrance = openingCsEntrances[i];
-
-            if (!strcmp(nextStage->mStage, libtp::data::stage::allStages[entrance[0]]) && nextStage->mRoomNo == entrance[1] &&
-                nextStage->mPoint == entrance[2] && nextStage->mLayer == entrance[3])
-            {
-                return true;
-            }
-        }
-        return false;
-    }
-
     KEEP_FUNC void handle_dStage_Create()
     {
         using namespace libtp::tp;
 
-        // When proceeding from the opening cutscene to the game, fix issue
-        // where Epona's position will remain wherever it was when the opening
-        // cutscene ended (either through skipping or ending naturally). We
-        // check against GAME_ACTIVE so we know we aren't returning to the title
-        // screen. Epona's stage is set to a fake value so that comparing the
-        // current stage against it never matches. This means Epona will not
-        // appear until the game specifically puts her somewhere (such as when
-        // you walk to Ordon Spring at the start of the prologue) or the player
-        // calls her, both of which overwrite the horse place to a normal value.
-        if (rando::gRandomizer->getGameState() == GameState::GAME_ACTIVE)
+        // Fix issue where Epona's position will remain wherever it was when the opening cutscene ends. Epona's stage
+        // is set to a fake value so the current stage never matches it. This means Epona will not appear until the
+        // game repositions her or the player calls her.
+        if (rando::gRandomizer->getGameState() == GameState::GAME_ACTIVE) // Check not changing to title screen
         {
             bool prevStageWasOpeningCutscene = false;
 
-            // Check string starts "Demo01_0". These comparisons are done over
-            // string compares since it uses fewer instruction bytes, executes
-            // fewer instructions, and does not require extra string data.
+            // Check string starts "Demo01_0". Written this way to improve size and execution.
             const uint32_t* demoNameAsWords = reinterpret_cast<const uint32_t*>(d_stage::mDemoArcName);
             if (demoNameAsWords[0] == 0x44656D6F && demoNameAsWords[1] == 0x30315F30) // "Demo" and "01_0"
             {
@@ -844,8 +811,7 @@ namespace mod
                 if (demoNameAsBytes[9] == 0) // Check strLen is 9
                 {
                     uint8_t lastCharByte = demoNameAsBytes[8];
-                    // Check final char in string is "1", "2", or "3", meaning
-                    // the string is "Demo01_01", "Demo01_02", or "Demo01_03".
+                    // Check str is "Demo01_01", "Demo01_02", or "Demo01_03" (opening cutscene demos).
                     if (lastCharByte >= 0x31 && lastCharByte <= 0x33) // "1", "2", or "3"
                     {
                         prevStageWasOpeningCutscene = true;
@@ -853,14 +819,29 @@ namespace mod
                 }
             }
 
-            if (prevStageWasOpeningCutscene && !nextStageIsOpeningCutscene())
+            if (prevStageWasOpeningCutscene)
             {
-                // Moving from the opening cutscene into the first stage outside
-                // of the opening cs, so hide Epona until the game manually
-                // places her or the player calls her.
-                strncpy(d_com_inf_game::dComIfG_gameInfo.save.save_file.player.horse_place.epona_current_stage,
-                        "FAKESTG",
-                        sizeof(d_com_inf_game::dComIfG_gameInfo.save.save_file.player.horse_place.epona_current_stage) - 1);
+                bool nextStageIsOpeningCutscene = false;
+                libtp::tp::d_stage::dStage_nextStage* nextStage = &libtp::tp::d_com_inf_game::dComIfG_gameInfo.play.mNextStage;
+                if (nextStage->mRoomNo == 1)
+                {
+                    if ((!strcmp(nextStage->mStage, libtp::data::stage::allStages[StageIDs::Ordon_Spring]) &&
+                         nextStage->mLayer == 0xD) ||
+                        (!strcmp(nextStage->mStage, libtp::data::stage::allStages[StageIDs::Ordon_Village]) &&
+                         nextStage->mLayer == 0x9))
+                    {
+                        nextStageIsOpeningCutscene = true;
+                    }
+                }
+
+                if (!nextStageIsOpeningCutscene)
+                {
+                    // Moving from the opening cutscene into the first stage outside of the opening cs, so hide Epona
+                    // until the game manually places her or the player calls her.
+                    strncpy(d_com_inf_game::dComIfG_gameInfo.save.save_file.player.horse_place.epona_current_stage,
+                            "FAKESTG",
+                            sizeof(d_com_inf_game::dComIfG_gameInfo.save.save_file.player.horse_place.epona_current_stage) - 1);
+                }
             }
         }
 

--- a/GameCube/subrel/boot/source/main.cpp
+++ b/GameCube/subrel/boot/source/main.cpp
@@ -136,6 +136,7 @@ namespace mod
         gReturn_roomLoader = patch::hookFunction(libtp::tp::d_stage::roomLoader, handle_roomLoader);
         gReturn_stageLoader = patch::hookFunction(libtp::tp::d_stage::stageLoader, handle_stageLoader);
         gReturn_dStage_playerInit = patch::hookFunction(libtp::tp::d_stage::dStage_playerInit, handle_dStage_playerInit);
+        gReturn_dStage_Create = patch::hookFunction(libtp::tp::d_stage::dStage_Create, handle_dStage_Create);
 
         // Only hook dComIfGp_setNextStage if there is at least one shuffled entrance
         if (seedPtr->getNumShuffledEntrances() > 0)


### PR DESCRIPTION
- Fully tested on all versions.
- There are comments in the code, but essentially when loading into a new stage when coming from the opening cutscene, at a very high level before most stage loading code runs, we update Epona's place stage name to be a value that never shows up in the game. This way, when the d_a_horse REL compares against the string (which happens when you enter a stage and aren't on Epona), it will never match. This means Epona effectively will not appear until she is repositioned by the game or the player calls her.