### PR TITLE
Fix transformAnywhere and quick transform issues

### DIFF
--- a/GameCube/assets/eu.lst
+++ b/GameCube/assets/eu.lst
@@ -61,6 +61,7 @@
 80032c58:isDarkClearLV
 80032c94:isTransformLV
 80034990:isSwitch_dSv_memBit
+80034d18:isSwitch_dSv_danBit
 800333a0:setLineUpItem
 80034aec:isEventBit
 80034a64:isDungeonItem

--- a/GameCube/assets/jp.lst
+++ b/GameCube/assets/jp.lst
@@ -66,6 +66,7 @@
 80035200:onSwitch_dSv_info
 800352b0:offSwitch_dSv_info
 80034838:offSwitch_dSv_memBit
+80034be8:isSwitch_dSv_danBit
 80034dac:onOneSwitch
 803a13e8:saveBitLabels
 80032bb0:isDarkClearLV

--- a/GameCube/assets/us.lst
+++ b/GameCube/assets/us.lst
@@ -71,6 +71,7 @@
 80035200:onSwitch_dSv_info
 80034838:offSwitch_dSv_memBit
 80034860:isSwitch_dSv_memBit
+80034be8:isSwitch_dSv_danBit
 80034dac:onOneSwitch
 800332f8:setLineUpItem
 80034368:onLightDropGetFlag

--- a/GameCube/source/events.cpp
+++ b/GameCube/source/events.cpp
@@ -1037,10 +1037,14 @@ namespace mod::events
     {
         if (checkValidTransformAnywhere())
         {
-            // Return false to allow transforming infront of NPCs using Midna's transform option
-            return 0;
+            // Even with transform anywhere enabled, we still need to do the PoT dark fog comparison.
+            if (libtp::tp::d_kankyo::env_light.mEvilPacketEnabled & 0x80)
+            {
+                return 3;
+            }
+            return 0; // Nothing preventing transforming
         }
-
+        // If transform anywhere is not enabled, do the vanilla comparisons.
         return gReturn_query042(unk1, unk2, unk3);
     }
 
@@ -1804,6 +1808,12 @@ namespace mod::events
             return;
         }
 
+        // Check that the player is not in PoT dark fog.
+        if (libtp::tp::d_kankyo::env_light.mEvilPacketEnabled & 0x80)
+        {
+            return;
+        }
+
         if (!checkValidTransformAnywhere())
         {
             if (daMidna_c__checkMetamorphoseEnableBase)
@@ -1815,10 +1825,23 @@ namespace mod::events
                 }
             }
 
-            // Check if the player has scared someone in the current area in wolf form
-            if ((libtp::tp::d_kankyo::env_light.mEvilPacketEnabled & 0x80) != 0)
+            // The following checks are from the query042:
+            // If the player is in Castle Town and has scared NPCs, they cannot transform.
+            if (!strcmp(dComIfG_gameInfo.play.mStartStage.mStage,
+                        libtp::data::stage::allStages[libtp::data::stage::StageIDs::Castle_Town]) &&
+                libtp::tp::d_save::isSwitch_dSv_danBit(&dComIfG_gameInfo.save.mDan, 0x3C))
             {
                 return;
+            }
+
+            if (libtp::tp::d_a_player::m_midnaActor != nullptr)
+            {
+                // Check against NpcNear and NpcFar
+                uint32_t midnaStateFlg0 = libtp::tp::d_a_player::m_midnaActor->mStateFlg0;
+                if ((midnaStateFlg0 & 0x100000) || (midnaStateFlg0 & 0x40000))
+                {
+                    return;
+                }
             }
         }
 


### PR DESCRIPTION
- Disallow transforming in PoT fog. You were able to do this with or without quick transform, and it allowed you to stand in the fog and clawshot out of it for example.
- Update quickTransform logic when transformAnywhere is disabled to match.