### PR TITLE
Update Lake Hylia spawn when save+quitting after warping there

### DIFF
--- a/GameCube/source/game_patch/07_checkPlayerStageReturn.cpp
+++ b/GameCube/source/game_patch/07_checkPlayerStageReturn.cpp
@@ -38,6 +38,11 @@ namespace mod::game_patch
                         playerReturnPlacePtr->link_spawn_point_id = 5; // Snowpeak doesn't have a valid spawn 0 on the mountain.
                         break;
                     }
+                    case StageIDs::Lake_Hylia:
+                    {
+                        playerReturnPlacePtr->link_spawn_point_id = 133; // Outside Lanayru Spring (vanilla)
+                        break;
+                    }
                     default:
                     {
                         playerReturnPlacePtr->link_spawn_point_id =


### PR DESCRIPTION
- Change from the fallback 0 to the vanilla "outside Lanayru Spring" spawn